### PR TITLE
Be predictable in the setter that is used on beans.

### DIFF
--- a/rsf-core/ponderutilcore/test/uk/org/ponder/saxalizer/support/TestSAXAccessMethod.java
+++ b/rsf-core/ponderutilcore/test/uk/org/ponder/saxalizer/support/TestSAXAccessMethod.java
@@ -1,0 +1,58 @@
+package uk.org.ponder.saxalizer.support;
+
+
+import junit.framework.TestCase;
+import uk.org.ponder.saxalizer.SAXAccessMethodSpec;
+
+
+public class TestSAXAccessMethod extends TestCase {
+
+    public void testMultipleSetters() {
+        // Check that when there are multiple setters the found method is consistent.
+        // It sorts the parameters classes as string so will prefer one nearer the start of the alphabet
+        {
+            SAXAccessMethodSpec spec = new SAXAccessMethodSpec();
+            spec.setmethodname = "setValue";
+            SAXAccessMethod accessMethod = new SAXAccessMethod(spec, TestClass.class);
+            assertEquals(Object.class, accessMethod.setmethod.getParameterTypes()[0]);
+        }
+        {
+            SAXAccessMethodSpec spec = new SAXAccessMethodSpec();
+            spec.setmethodname = "setOther";
+            SAXAccessMethod accessMethod = new SAXAccessMethod(spec, TestClass.class);
+            assertEquals(Boolean.class, accessMethod.setmethod.getParameterTypes()[0]);
+        }
+        {
+            SAXAccessMethodSpec spec = new SAXAccessMethodSpec();
+            spec.setmethodname = "setThing";
+            SAXAccessMethod accessMethod = new SAXAccessMethod(spec, TestClass.class);
+            assertEquals(Float.class, accessMethod.setmethod.getParameterTypes()[0]);
+        }
+        {
+            SAXAccessMethodSpec spec = new SAXAccessMethodSpec();
+            spec.setmethodname = "setThat";
+            SAXAccessMethod accessMethod = new SAXAccessMethod(spec, TestClass.class);
+            assertEquals(Boolean.class, accessMethod.setmethod.getParameterTypes()[0]);
+        }
+    }
+
+    public class TestClass {
+
+        public void setValue(Object val) {}
+        public void setValue(String val) {}
+
+        public void setOther(Object val) {}
+        public void setOther(Boolean val) {}
+
+        public void setThing(Float val) {}
+        public void setThing(Object val) {}
+
+        public void setThat(Boolean val) {}
+        public void setThat(Float val) {}
+        public void setThat(Integer val) {}
+        public void setThat(Object val) {}
+        public void setThat(String val) {}
+
+
+    }
+}


### PR DESCRIPTION
When attempting to find a setter on a bean RSF just uses the first method that matches the desired name, returns void and has a single argument. The JVM doesn’t sort the returned methods from a class so if there are two that match these requirements it’s not deterministic about which one will get found.

The clean(er) solution would have been to throw an error if we found more than one setter, but this would have broken some calling code so instead we sort all the found setters to ensure that the results are at least always the same.

We assume that in most cases we won’t find more than one setter so delay the use of an ArrayList.

Fixes #5